### PR TITLE
Added support for ignoring stdout/stderr via stdio

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,20 @@ function execute(command, args, options) {
 
     // Buffer output, reporting progress
     process = spawn(command, args, options);
-    process.stdout.on('data', function (data) {
-        stdout = Buffer.concat([stdout, data]);
-        data.type = 'stdout';
-        deferred.notify(data);
-    });
-    process.stderr.on('data', function (data) {
-        stderr = Buffer.concat([stderr, data]);
-        data.type = 'stderr';
-        deferred.notify(data);
-    });
+    if (process.stdout) {
+        process.stdout.on('data', function (data) {
+            stdout = Buffer.concat([stdout, data]);
+            data.type = 'stdout';
+            deferred.notify(data);
+        });
+    }
+    if (process.stderr) {
+        process.stderr.on('data', function (data) {
+            stderr = Buffer.concat([stderr, data]);
+            data.type = 'stderr';
+            deferred.notify(data);
+        });
+    }
 
     // If there is an error spawning the command, reject the promise
     process.on('error', function (error) {

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,32 @@ describe('buffered-spawn', function () {
             });
         });
 
+        it('should allow node\'s spawn\'s stdout to be ignored', function (next) {
+            buffspawn('node', ['simple'], {
+                cwd: __dirname + '/fixtures',
+                stdio: ['pipe', 'ignore', 'pipe']
+            }, function (err, stdout, stderr) {
+                expect(err).to.not.be.ok();
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('i am being printed on stderr');
+
+                next();
+            });
+        });
+
+        it('should allow node\'s spawn\'s stderr to be ignored', function (next) {
+            buffspawn('node', ['simple'], {
+                cwd: __dirname + '/fixtures',
+                stdio: ['pipe', 'pipe', 'ignore']
+            }, function (err, stdout, stderr) {
+                expect(err).to.not.be.ok();
+                expect(stdout).to.equal('i am being printed on stdout');
+                expect(stderr).to.equal('');
+
+                next();
+            });
+        });
+
         it('should work with promises', function (next) {
             var progressCount = 0;
 


### PR DESCRIPTION
In uber/image-diff#23 we need support for ignoring `stdout` to prevent buffering a large unused image into memory. `child_process.spawn` supports this via setting `ignore` in `stdio`:

https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options

https://nodejs.org/api/child_process.html#child_process_options_stdio

When this is set, `process.stdout` is no longer accessible. As a result, `buffered-spawn's` current implementation breaks. This PR repairs that. In this PR:

- Added tests against `stdio` setting `ignore` for `stdout` and `stderr`
- Added support for `process.stdout` and `process.stderr` not existing